### PR TITLE
JDBC in common libs + auto-gen SSH key

### DIFF
--- a/appserver-cloud_init.tf
+++ b/appserver-cloud_init.tf
@@ -1,0 +1,23 @@
+## Copyright © 2020, Oracle and/or its affiliates. 
+## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
+
+data "template_file" "key_script" {
+  template = "${file("./templates/sshkey.tpl")}"
+  vars = {
+    "ssh_public_key" = "${tls_private_key.opc_key.public_key_openssh}"
+  }
+}
+
+# Render a multi-part cloud-init config making use of the part
+# above, and other source files
+data "template_cloudinit_config" "app_server_cloud_init" {
+  gzip          = true
+  base64_encode = true
+
+  part {
+    filename     = "ainit.sh"
+    content_type = "text/x-shellscript"
+    content      = "${data.template_file.key_script.rendered}"
+  }
+
+}

--- a/appserver-config.tf
+++ b/appserver-config.tf
@@ -25,10 +25,11 @@ resource "null_resource" "Webserver1_ConfigMgmt" {
     "sudo yum install -y ant",
     "cd ~",
     "curl -LO -H 'Cookie: oraclelicense=accept-securebackup-cookie' -O https://download.oracle.com/otn-pub/otn_software/jdbc/ojdbc8-full.tar.gz",
+    # untar the JDBC driver in the common lib folder
     "sudo tar -xvf ojdbc8-full.tar.gz --strip 1 -C /usr/share/java/tomcat/",
     # this jar conflicts with the driver in same cases
     "sudo rm -f /usr/share/java/tomcat/xmlparserv2.jar",
-    # other missing jar
+    # missing jar to create connection with older jdk
     "sudo wget -O /usr/share/java/tomcat/tomcat-dbcp-7.0.76.jar http://search.maven.org/remotecontent?filepath=org/apache/tomcat/tomcat-dbcp/7.0.76/tomcat-dbcp-7.0.76.jar",
     "sudo firewall-cmd --add-port=8080/tcp --permanent",
     "sudo firewall-cmd --reload",
@@ -119,7 +120,6 @@ resource "null_resource" "Webserver1_Tomcat_Build" {
       "sed -i -e 's@jdbc/orcljdbc_ds@tomcat/UCP_atp@' ~/oracle-db-examples/java/jdbc/Tomcat_Servlet/src/JDBCSample_Servlet.java",
       "cd ~/oracle-db-examples/java/jdbc/Tomcat_Servlet",
       "mkdir -p /home/opc/oracle-db-examples/java/jdbc/Tomcat_Servlet/WEB-INF/lib",
-      # "cp -v ~/ojdbc8-full/* /home/opc/oracle-db-examples/java/jdbc/Tomcat_Servlet/WEB-INF/lib/",
       "ant",
       "sudo cp /home/opc/oracle-db-examples/java/jdbc/Tomcat_Servlet/dist/JDBCSample.war /usr/share/tomcat/webapps/",
       "sudo systemctl restart tomcat"

--- a/appserver-config.tf
+++ b/appserver-config.tf
@@ -1,5 +1,9 @@
 # Copyright (c) 2020, Oracle and/or its affiliates. 
 # All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
+resource "tls_private_key" "opc_key" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
 
 resource "null_resource" "Webserver1_ConfigMgmt" {
   depends_on = [oci_core_instance.webserver1, oci_database_autonomous_database.ATPdatabase]
@@ -9,7 +13,7 @@ resource "null_resource" "Webserver1_ConfigMgmt" {
       type        = "ssh"
       user        = "opc"
       host        = data.oci_core_vnic.webserver1_primaryvnic[count.index].public_ip_address
-      private_key = file(var.ssh_private_key)
+      private_key = tls_private_key.opc_key.private_key_pem
       script_path = "/home/opc/myssh.sh"
       agent       = false
       timeout     = "10m"
@@ -21,7 +25,11 @@ resource "null_resource" "Webserver1_ConfigMgmt" {
     "sudo yum install -y ant",
     "cd ~",
     "curl -LO -H 'Cookie: oraclelicense=accept-securebackup-cookie' -O https://download.oracle.com/otn-pub/otn_software/jdbc/ojdbc8-full.tar.gz",
-    "tar zxf ojdbc8-full.tar.gz",
+    "sudo tar -xvf ojdbc8-full.tar.gz --strip 1 -C /usr/share/java/tomcat/",
+    # this jar conflicts with the driver in same cases
+    "sudo rm -f /usr/share/java/tomcat/xmlparserv2.jar",
+    # other missing jar
+    "sudo wget -O /usr/share/java/tomcat/tomcat-dbcp-7.0.76.jar http://search.maven.org/remotecontent?filepath=org/apache/tomcat/tomcat-dbcp/7.0.76/tomcat-dbcp-7.0.76.jar",
     "sudo firewall-cmd --add-port=8080/tcp --permanent",
     "sudo firewall-cmd --reload",
     "sudo systemctl enable --now tomcat",
@@ -52,7 +60,7 @@ resource "null_resource" "Webserver1_ConfigMgmt" {
       type        = "ssh"
       user        = "opc"
       host        = data.oci_core_vnic.webserver1_primaryvnic[count.index].public_ip_address
-      private_key = file(var.ssh_private_key)
+      private_key = tls_private_key.opc_key.private_key_pem
       script_path = "/home/opc/myssh.sh"
       agent       = false
       timeout     = "10m"
@@ -66,7 +74,7 @@ resource "null_resource" "Webserver1_ConfigMgmt" {
       type        = "ssh"
       user        = "opc"
       host        = data.oci_core_vnic.webserver1_primaryvnic[count.index].public_ip_address
-      private_key = file(var.ssh_private_key)
+      private_key = tls_private_key.opc_key.private_key_pem
       script_path = "/home/opc/myssh.sh"
       agent       = false
       timeout     = "10m"
@@ -80,7 +88,7 @@ resource "null_resource" "Webserver1_ConfigMgmt" {
       type        = "ssh"
       user        = "opc"
       host        = data.oci_core_vnic.webserver1_primaryvnic[count.index].public_ip_address
-      private_key = file(var.ssh_private_key)
+      private_key = tls_private_key.opc_key.private_key_pem
       script_path = "/home/opc/myssh.sh"
       agent       = false
       timeout     = "10m"
@@ -100,7 +108,7 @@ resource "null_resource" "Webserver1_Tomcat_Build" {
       type        = "ssh"
       user        = "opc"
       host        = data.oci_core_vnic.webserver1_primaryvnic[count.index].public_ip_address
-      private_key = file(var.ssh_private_key)
+      private_key = tls_private_key.opc_key.private_key_pem
       script_path = "/home/opc/myssh.sh"
       agent       = false
       timeout     = "10m"
@@ -111,7 +119,7 @@ resource "null_resource" "Webserver1_Tomcat_Build" {
       "sed -i -e 's@jdbc/orcljdbc_ds@tomcat/UCP_atp@' ~/oracle-db-examples/java/jdbc/Tomcat_Servlet/src/JDBCSample_Servlet.java",
       "cd ~/oracle-db-examples/java/jdbc/Tomcat_Servlet",
       "mkdir -p /home/opc/oracle-db-examples/java/jdbc/Tomcat_Servlet/WEB-INF/lib",
-      "cp -v ~/ojdbc8-full/* /home/opc/oracle-db-examples/java/jdbc/Tomcat_Servlet/WEB-INF/lib/",
+      # "cp -v ~/ojdbc8-full/* /home/opc/oracle-db-examples/java/jdbc/Tomcat_Servlet/WEB-INF/lib/",
       "ant",
       "sudo cp /home/opc/oracle-db-examples/java/jdbc/Tomcat_Servlet/dist/JDBCSample.war /usr/share/tomcat/webapps/",
       "sudo systemctl restart tomcat"

--- a/appserver.tf
+++ b/appserver.tf
@@ -10,7 +10,7 @@ resource "oci_core_instance" "webserver1" {
   count = var.numberOfNodes
   availability_domain = data.oci_identity_availability_domains.ADs.availability_domains[1]["name"]
   compartment_id = var.compartment_ocid
-  display_name = "tomcat01"
+  display_name = "tomcat-${count.index}"
   shape = var.InstanceShape
 
   create_vnic_details {
@@ -28,6 +28,7 @@ resource "oci_core_instance" "webserver1" {
 
   metadata = {
     ssh_authorized_keys = var.ssh_public_key
+    user_data = data.template_cloudinit_config.app_server_cloud_init.rendered
   }
   # timeouts {
   #   create = "60m"

--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,6 @@ variable "region" {}
 variable "tenancy_ocid" {}
 variable "compartment_ocid" {}
 variable "ssh_public_key" {}
-variable "ssh_private_key" {}
 
 variable "igw_display_name" {
   default = "internet-gateway"


### PR DESCRIPTION
- Move the JDBC driver to the common lib folder so it is usable by all apps deploys
- modify Terraform to make use of a public/private key pair generated for the deployment (no need to provide a private key)

Signed-off: Emmanuel Leroy <emmanuel.leroy@oracle.com>