### PR TITLE
Multiple fixes

### DIFF
--- a/appserver-cloud_init.tf
+++ b/appserver-cloud_init.tf
@@ -2,9 +2,9 @@
 ## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
 
 data "template_file" "key_script" {
-  template = "${file("./templates/sshkey.tpl")}"
+  template = file("./templates/sshkey.tpl")
   vars = {
-    "ssh_public_key" = "${tls_private_key.opc_key.public_key_openssh}"
+    "ssh_public_key" = tls_private_key.opc_key.public_key_openssh
   }
 }
 
@@ -17,7 +17,7 @@ data "template_cloudinit_config" "app_server_cloud_init" {
   part {
     filename     = "ainit.sh"
     content_type = "text/x-shellscript"
-    content      = "${data.template_file.key_script.rendered}"
+    content      = data.template_file.key_script.rendered
   }
 
 }

--- a/appserver-config.tf
+++ b/appserver-config.tf
@@ -6,20 +6,19 @@ resource "tls_private_key" "opc_key" {
 }
 
 resource "null_resource" "Webserver1_ConfigMgmt" {
-  depends_on = [oci_core_instance.webserver1, oci_database_autonomous_database.ATPdatabase]
+  depends_on = [oci_core_instance.webserver, oci_database_autonomous_database.ATPdatabase]
   count = var.numberOfNodes
   provisioner "remote-exec" {
     connection {
       type        = "ssh"
       user        = "opc"
-      host        = data.oci_core_vnic.webserver1_primaryvnic[count.index].public_ip_address
+      host        = oci_core_instance.webserver[count.index].public_ip
       private_key = tls_private_key.opc_key.private_key_pem
-      script_path = "/home/opc/myssh.sh"
       agent       = false
       timeout     = "10m"
     }
     inline = [
-    "sudo yum update -y",
+    # "sudo yum update -y",
     "sudo yum install -y tomcat",
     "sudo yum install -y git",
     "sudo yum install -y ant",
@@ -60,9 +59,8 @@ resource "null_resource" "Webserver1_ConfigMgmt" {
     connection {
       type        = "ssh"
       user        = "opc"
-      host        = data.oci_core_vnic.webserver1_primaryvnic[count.index].public_ip_address
+      host        = oci_core_instance.webserver[count.index].public_ip
       private_key = tls_private_key.opc_key.private_key_pem
-      script_path = "/home/opc/myssh.sh"
       agent       = false
       timeout     = "10m"
     }
@@ -74,9 +72,8 @@ resource "null_resource" "Webserver1_ConfigMgmt" {
     connection {
       type        = "ssh"
       user        = "opc"
-      host        = data.oci_core_vnic.webserver1_primaryvnic[count.index].public_ip_address
+      host        = oci_core_instance.webserver[count.index].public_ip
       private_key = tls_private_key.opc_key.private_key_pem
-      script_path = "/home/opc/myssh.sh"
       agent       = false
       timeout     = "10m"
     }
@@ -88,9 +85,8 @@ resource "null_resource" "Webserver1_ConfigMgmt" {
     connection {
       type        = "ssh"
       user        = "opc"
-      host        = data.oci_core_vnic.webserver1_primaryvnic[count.index].public_ip_address
+      host        = oci_core_instance.webserver[count.index].public_ip
       private_key = tls_private_key.opc_key.private_key_pem
-      script_path = "/home/opc/myssh.sh"
       agent       = false
       timeout     = "10m"
     }
@@ -108,9 +104,8 @@ resource "null_resource" "Webserver1_Tomcat_Build" {
     connection {
       type        = "ssh"
       user        = "opc"
-      host        = data.oci_core_vnic.webserver1_primaryvnic[count.index].public_ip_address
+      host        = oci_core_instance.webserver[count.index].public_ip
       private_key = tls_private_key.opc_key.private_key_pem
-      script_path = "/home/opc/myssh.sh"
       agent       = false
       timeout     = "10m"
     }

--- a/appserver.tf
+++ b/appserver.tf
@@ -6,7 +6,7 @@ data "oci_core_images" "OSImageLocal" {
   display_name   = var.OsImage
 }
 
-resource "oci_core_instance" "webserver1" {
+resource "oci_core_instance" "webserver" {
   count = var.numberOfNodes
   availability_domain = data.oci_identity_availability_domains.ADs.availability_domains[1]["name"]
   compartment_id = var.compartment_ocid
@@ -35,18 +35,6 @@ resource "oci_core_instance" "webserver1" {
   # }
 }
 
-data "oci_core_vnic_attachments" "webserver1_primaryvnic_attach" {
-  count = var.numberOfNodes
-  availability_domain = lookup(data.oci_identity_availability_domains.ADs.availability_domains[1], "name")
-  compartment_id = var.compartment_ocid
-  instance_id         = oci_core_instance.webserver1[count.index].id
-}
-
-data "oci_core_vnic" "webserver1_primaryvnic" {
-  count = var.numberOfNodes
-  vnic_id = data.oci_core_vnic_attachments.webserver1_primaryvnic_attach[count.index].vnic_attachments.0.vnic_id
-}
-
-# output "webserver1_PublicIP" {
-#   value = [data.oci_core_vnic.webserver1_primaryvnic[count.index].public_ip_address]
-# }
+output "Tomcat_PublicIPs" {
+  value = oci_core_instance.webserver[*].public_ip
+} 

--- a/lb.tf
+++ b/lb.tf
@@ -41,7 +41,7 @@ resource "oci_load_balancer_backend" "lb_be_webserver1" {
   count = var.numberOfNodes
   load_balancer_id = oci_load_balancer.lb01.id
   backendset_name  = oci_load_balancer_backend_set.lb_be_app01.name
-  ip_address       = oci_core_instance.webserver1[count.index].private_ip
+  ip_address       = oci_core_instance.webserver[count.index].private_ip
   port             = 8080
   backup           = false
   drain            = false
@@ -49,3 +49,6 @@ resource "oci_load_balancer_backend" "lb_be_webserver1" {
   weight           = 1
 }
 
+output "LoadBalancerIP" {
+  value = oci_load_balancer.lb01.ip_address_details
+}


### PR DESCRIPTION
Fix a few issues I have been having:

1) Scaling: When Applying the tf with a numberOfNodes=1 and then going to 2, I get this error:
```
Error: Invalid index

  on appserver.tf line 47, in data "oci_core_vnic" "webserver1_primaryvnic":
  47:   vnic_id = data.oci_core_vnic_attachments.webserver1_primaryvnic_attach[count.index].vnic_attachments.0.vnic_id
    |----------------
    | count.index is 1
    | data.oci_core_vnic_attachments.webserver1_primaryvnic_attach is tuple with 1 element
```
which I fixed by using the `oci_core_instance.webserver[count.index].public_ip` syntax instead.

2) There were some deprecation warning fixed (interpolation)
3) I removed the `yum update -y` first line in the appserver-config.tf as it was taking very long to deploy (20min), and doesn't seem to make a difference. Without the update it is much faster. Let me know if there were issues without it; I have not seen any.

4) I created outputs for the Public IPs of the Tomcat servers as well as the load balancer IP. It makes life a lot easier than having to go look those up in the Web console.

Signed-off: Emmanuel Leroy <emmanuel.leroy@oracle.com>
